### PR TITLE
Remove auth plug when env != "prod"

### DIFF
--- a/lib/habits_web/router.ex
+++ b/lib/habits_web/router.ex
@@ -16,8 +16,10 @@ defmodule HabitsWeb.Router do
   end
 
   pipeline :protected do
-    plug Pow.Plug.RequireAuthenticated,
-      error_handler: HabitsWeb.APIAuthErrorHandler
+    if Mix.env() === :prod do
+      plug Pow.Plug.RequireAuthenticated,
+        error_handler: HabitsWeb.APIAuthErrorHandler
+    end
   end
 
   pipeline :browser do


### PR DESCRIPTION
Need to access db when using codegen on the client side.